### PR TITLE
Fix open first tab loading

### DIFF
--- a/src/tab.py
+++ b/src/tab.py
@@ -184,7 +184,7 @@ class TabObject:
             logging.error("WebDriverException: Can't Switch to New Tab")
         self.link = "http://www.google.com"
         if link:
-            link = self.validateURL(link)
+            self.link = self.validateURL(link)
         self.openPage(self.link)
 
     def update(self):
@@ -244,5 +244,4 @@ class TabObject:
             link = "http://{}".format(link)
         if link == "http://www.google.com" or link == "www.google.com":
             return link
-        self.link = link
         return link


### PR DESCRIPTION
If a link is specified in Chrome Browser mode, then it should go to that page first instead of going to Google.com. Right now it goes to google, and then changes to the site.